### PR TITLE
Export additional API for public consumption

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,13 @@
+// @NOTE
+// - Required for custom `AnnotationLayer`
+export { usePDFPage } from "@/lib/pdf/page";
+export { useVisibility } from "@/lib/viewport";
+export { usePDFLinkService } from "@/lib/pdf/links";
+
+// @NOTE
+// - Required for `Viewer`
+export { usePDFDocument } from "@/lib/pdf/document";
+
+// @NOTE
+// - Defaults
 export * from "@/components";


### PR DESCRIPTION
### Overview

- Exposes internal API's required for custom `AnnotationLayer`
- Exposes `usePDFDocument` as per https://github.com/OnedocLabs/pdfreader/issues/4

### Notes

- Once validated will add docs to Storybook and PR back upstream.