### PR TITLE
Hoist Viewport provider to it's own component

### DIFF
--- a/src/components/Root/index.tsx
+++ b/src/components/Root/index.tsx
@@ -7,7 +7,7 @@ import {
   useCreatePDFLinkService,
   PDFLinkServiceContext,
 } from "@/lib/pdf/links";
-import { useViewportContext, ViewportContext } from "@/lib/viewport";
+import { useViewportContext } from "@/lib/viewport";
 import { forwardRef, HTMLProps, ReactNode } from "react";
 import { Primitive } from "../Primitive";
 
@@ -37,11 +37,9 @@ export const Root = forwardRef(
       <Primitive.div ref={ref} {...props}>
         {ready ? (
           <PDFDocumentContext.Provider value={context}>
-            <ViewportContext.Provider value={viewportContext}>
-              <PDFLinkServiceContext.Provider value={linkService}>
-                {children}
-              </PDFLinkServiceContext.Provider>
-            </ViewportContext.Provider>
+            <PDFLinkServiceContext.Provider value={linkService}>
+              {children}
+            </PDFLinkServiceContext.Provider>
           </PDFDocumentContext.Provider>
         ) : (
           loader || "Loading..."

--- a/src/components/Viewport/index.tsx
+++ b/src/components/Viewport/index.tsx
@@ -1,6 +1,15 @@
-import { useViewportContainer } from "@/lib/viewport";
-import { HTMLProps, useRef } from "react";
 import { Primitive } from "../Primitive";
+import { type HTMLProps, type ReactNode, useRef } from "react";
+import { useViewportContainer, useViewportContext, ViewportContext } from "@/lib/viewport";
+
+export const ViewportProvider = ({ children }: { children: ReactNode }) => {
+  const viewportContext = useViewportContext({});
+  return (
+    <ViewportContext.Provider value={viewportContext}>
+      {children}
+    </ViewportContext.Provider>
+  )
+}
 
 export const Viewport = ({ children, ...props }: HTMLProps<HTMLDivElement>) => {
   const containerRef = useRef<HTMLDivElement>(null);

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,5 +1,5 @@
 import "pdfjs-dist/web/pdf_viewer.css";
-import { Viewport } from "./Viewport";
+import { Viewport, ViewportProvider } from "./Viewport";
 import { useViewport } from "@/lib/viewport";
 import { Root } from "./Root";
 import { Page } from "./Page";
@@ -66,6 +66,7 @@ export {
   useViewport,
   // Components
   Viewport,
+  ViewportProvider,
   Root,
   Page,
   AnnotationLayer,


### PR DESCRIPTION
### Overview

This is the most significant change yet and breaks the current examples.

Now the `File` component (or in our case `File` _components_) must be wrapped in a `ViewportProvider`. This way the zoom level is shared across multiple `File` components (a problem the original lib didn't have because it only ever assumed one PDF would be loaded).

It can probably be optimised further but I am trying to keep changes to the fork as minimal as possible until we go whole hog and commit to maintaining our own renderer full time.

### Notes

I would like to update the respective examples to respect this change but right now it doesn't seem worth it.