### PR TITLE
Pass zoom directly to Canvas layer

### DIFF
--- a/src/components/Layers/index.tsx
+++ b/src/components/Layers/index.tsx
@@ -8,6 +8,10 @@ import { usePDFPage } from "@/lib/pdf/page";
 import clsx from "clsx";
 import { HTMLProps } from "react";
 
+type CanvasLayerProps = HTMLProps<HTMLCanvasElement> & {
+  zoom?: number;
+}
+
 export const TextLayer = ({
   className,
   style,
@@ -58,10 +62,11 @@ export const AnnotationLayer = ({
 };
 
 export const CanvasLayer = ({
+  zoom = 1,
   style,
   ...props
-}: HTMLProps<HTMLCanvasElement>) => {
-  const { canvasRef } = useCanvasLayer();
+}: CanvasLayerProps) => {
+  const { canvasRef } = useCanvasLayer({ zoom });
 
   return (
     <canvas

--- a/src/components/Page/index.tsx
+++ b/src/components/Page/index.tsx
@@ -1,5 +1,4 @@
 import { usePDFPageContext, PDFPageContext } from "@/lib/pdf/page";
-import { usePageViewport } from "@/lib/viewport";
 import { HTMLProps, ReactNode, useRef } from "react";
 import { Primitive } from "../Primitive";
 
@@ -14,8 +13,6 @@ export const Page = ({
 }) => {
   const pageContainerRef = useRef<HTMLDivElement>(null);
   const { ready, context } = usePDFPageContext(pageNumber);
-
-  usePageViewport({ pageContainerRef, pageNumber });
 
   return (
     <PDFPageContext.Provider value={context}>

--- a/src/lib/pdf/layers/canvas.ts
+++ b/src/lib/pdf/layers/canvas.ts
@@ -1,17 +1,20 @@
 import { useDebounce } from "@uidotdev/usehooks";
 import { useEffect, useRef } from "react";
 
-import { useDPR, useViewport } from "@/lib/viewport";
+import { useDPR } from "@/lib/viewport";
 
 import { usePDFPage } from "../page";
 import { AnnotationMode } from "pdfjs-dist";
 
-export const useCanvasLayer = () => {
+type UseCanvasLayerParams = {
+  zoom: number;
+}
+
+export const useCanvasLayer = ({ zoom: scale }: UseCanvasLayerParams) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const { pdfPageProxy } = usePDFPage();
   const dpr = useDPR();
-  const { zoom: bouncyZoom } = useViewport();
-  const zoom = useDebounce(bouncyZoom, 100);
+  const zoom = useDebounce(scale, 100);
 
   useEffect(() => {
     if (!canvasRef.current) {


### PR DESCRIPTION
### Overview

- Removes the need for the viewport component and instead passes `zoom` directly to the `CanvasLayer`

### To Do

- Undo changes made in https://github.com/feytools/pdfreader/pull/5 & https://github.com/feytools/pdfreader/pull/6